### PR TITLE
correct path and duplicate query parameters

### DIFF
--- a/src/http/fetch/multisearch.ts
+++ b/src/http/fetch/multisearch.ts
@@ -65,7 +65,7 @@ async function multisearch<const Searches extends readonly object[]>(
       const urlParams = new URLSearchParams(normalizeQueryParams(queryParams));
 
       return await makeRequest({
-        endpoint: `/multisearch?${urlParams.toString()}`,
+        endpoint: `/multi_search`,
         config: getConfiguration(config),
         method: "POST",
         body: searchParams,

--- a/tests/multisearch.test.ts
+++ b/tests/multisearch.test.ts
@@ -1,4 +1,5 @@
 import { configure } from "@/config";
+import { RequestError } from "@/error";
 import { collection } from "@/http/fetch";
 import { multisearch } from "@/http/fetch/multisearch";
 import { multisearchEntry } from "@/multisearch";
@@ -1007,6 +1008,60 @@ describe("multisearch tests", () => {
         expect(res_1).not.toHaveProperty("search_time_ms");
         expect(res_2.search_time_ms).toBeDefined();
       });
+    });
+  });
+  describe("query parameters", () => {
+    it("is successful when the number of searches equals limit_multi_searches", async () => {
+      const { results } = await multisearch(
+        {
+          searches: [
+            multisearchEntry({
+              collection: "multi_search_test_1",
+              q: "q",
+              query_by: ["foo"],
+            }),
+            multisearchEntry({
+              collection: "multi_search_test_2",
+              q: "q",
+              query_by: ["foo"],
+            }),
+          ],
+        },
+        config,
+        { limit_multi_searches: 2 },
+      );
+      expect(results.length).toEqual(2);
+    });
+    it("fails when the number of searches exceeds limit_multi_searches", async () => {
+      try {
+        await multisearch(
+          {
+            searches: [
+              multisearchEntry({
+                collection: "multi_search_test_1",
+                q: "q",
+                query_by: ["foo"],
+              }),
+              multisearchEntry({
+                collection: "multi_search_test_2",
+                q: "q",
+                query_by: ["foo"],
+              }),
+            ],
+          },
+          config,
+          { limit_multi_searches: 1 },
+        );
+
+        throw new Error("Expected multisearch to throw, but it did not");
+      } catch (error) {
+        expect(error).toBeInstanceOf(RequestError);
+        const reqError = error as RequestError;
+        expect(reqError.status).toBe(400);
+        expect(reqError.message).toContain(
+          "Number of multi searches exceeds `limit_multi_searches` parameter."
+        );
+      }
     });
   });
 });


### PR DESCRIPTION
Previously, when using query parameters in multisearch, two issues occurred:
1. The incorrect pathname `/multisearch` was used instead of `/multi_search`.
2. Query parameters were added to the URL twice.

For example: 
```
await multisearch({ searches }, config, { use_cache: true })
```
resulted in: 
```
http://localhost:8108/typesense/multisearch?use_cache=true?use_cache=true
```
Now it should result in the correct URL: 
```
http://localhost:8108/typesense/multi_search?use_cache=true
```
