### PR TITLE
fix(node): more permissive domain check

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -1,5 +1,5 @@
 type Protocol = "http" | "https";
-type Domain = `${string}.${string}` | `localhost`;
+type Domain = "localhost" | (string & {});
 type Port = `:${number}`;
 type Path = `/${string}${string}`;
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -142,10 +142,7 @@ describe("default configuration management", () => {
 
       const config2 = configure({
         apiKey: "api-key-2",
-        nodes: [
-          // @ts-expect-error - this host is invalid
-          { host: "different-host", port: 8109, protocol: "https" },
-        ],
+        nodes: [{ host: "different-host", port: 8109, protocol: "https" }],
       });
 
       setDefaultConfiguration(config1);
@@ -201,16 +198,12 @@ describe("default configuration management", () => {
     it("should return provided config when given", () => {
       const defaultConfig = configure({
         apiKey: "default-key",
-        // @ts-expect-error - this host is invalid
         nodes: [{ host: "default-host", port: 8108, protocol: "http" }],
       });
 
       const providedConfig = configure({
         apiKey: "provided-key",
-        nodes: [
-          // @ts-expect-error - this host is invalid
-          { host: "provided-host", port: 8109, protocol: "https" },
-        ],
+        nodes: [{ host: "provided-host", port: 8109, protocol: "https" }],
       });
 
       setDefaultConfiguration(defaultConfig);
@@ -222,7 +215,6 @@ describe("default configuration management", () => {
     it("should return default config when no config is provided", () => {
       const defaultConfig = configure({
         apiKey: "default-key",
-        // @ts-expect-error - this host is invalid
         nodes: [{ host: "default-host", port: 8108, protocol: "http" }],
       });
 
@@ -235,10 +227,7 @@ describe("default configuration management", () => {
     it("should return default config when undefined is explicitly passed", () => {
       const defaultConfig = configure({
         apiKey: "default-key",
-        nodes: [
-          // @ts-expect-error - this host is invalid
-          { host: "default-host", port: 8108, protocol: "http" },
-        ],
+        nodes: [{ host: "default-host", port: 8108, protocol: "http" }],
       });
 
       setDefaultConfiguration(defaultConfig);
@@ -283,13 +272,11 @@ describe("default configuration management", () => {
     it("should handle multiple configurations in sequence", () => {
       const config1 = configure({
         apiKey: "key-1",
-        //  @ts-expect-error - invalid host
         nodes: [{ host: "host-1", port: 8108, protocol: "http" }],
       });
 
       const config2 = configure({
         apiKey: "key-2",
-        //  @ts-expect-error - invalid host
         nodes: [{ host: "host-2", port: 8109, protocol: "https" }],
       });
 
@@ -310,12 +297,9 @@ describe("default configuration management", () => {
       const config = configure({
         apiKey: "complex-key",
         nodes: [
-          // @ts-expect-error - invalid host
           { host: "node1", port: 8108, protocol: "http" },
-          // @ts-expect-error - invalid host
           { host: "node2", port: 8109, protocol: "https" },
         ],
-        // @ts-expect-error - invalid host
         nearestNode: { url: "http://nearest-node" },
         randomizeNodes: true,
         connectionTimeoutSeconds: 10,

--- a/tests/node.test.ts
+++ b/tests/node.test.ts
@@ -79,30 +79,6 @@ describe("type tests", () => {
       // @ts-expect-error This is erroring as expected
       const _error: UrlString = "ftp://localhost:3000";
     });
-    it("should only let a path be prefixed with a slash", () => {
-      const _config: UrlString = "http://localhost:3000/a";
-      // @ts-expect-error This is erroring as expected
-      const _error: UrlString = "http://localhost:3000api";
-    });
-    it("should only let ports be numbers", () => {
-      const _config: UrlString = "http://localhost:3000";
-      // @ts-expect-error This is erroring as expected
-      const _error: UrlString = "http://localhost:port";
-    });
-    it("should only let domains be strings", () => {
-      const _config: UrlString = "http://localhost";
-      // @ts-expect-error This is erroring as expected
-      const _error: UrlString = "http://23:3000";
-    });
-    it("should not end on an empty path", () => {
-      const _config: UrlString = "http://localhost:3000";
-      // @ts-expect-error This is erroring as expected
-      const _error: UrlString = "http://localhost:3000/";
-    });
-    it("should let an empty path", () => {
-      const _port: UrlString = "http://localhost:3000";
-      const _empty: UrlString = "http://localhost";
-    });
   });
 });
 describe("function tests", () => {


### PR DESCRIPTION
Just provide an optional autocomplete for localhost, instead of restricting to template literals

fixes #5 