### PR TITLE
fix(node): make url type constraint just a string

### DIFF
--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,5 +1,3 @@
-import type { UrlString } from "@/node";
-
 type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 
 function constructUrl({
@@ -7,7 +5,7 @@ function constructUrl({
   params,
   endpoint,
 }: {
-  baseUrl: UrlString;
+  baseUrl: string;
   params?: URLSearchParams;
   endpoint?: `/${string}`;
 }) {

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,13 +1,9 @@
-type Protocol = "http" | "https";
 type Domain = "localhost" | (string & {});
-type Port = `:${number}`;
 type Path = `/${string}${string}`;
-
-type UrlString = `${Protocol}://${Domain}${Port | ""}${Path | ""}`;
 
 type NodeConfiguration =
   | {
-      url: UrlString;
+      url: (string & {}) | "http://localhost:8108";
       host?: never;
       port?: never;
       protocol?: never;
@@ -24,7 +20,7 @@ type NodeConfiguration =
 interface BaseNode {
   isHealthy: boolean;
   lastAccessTimestamp: number;
-  url: UrlString;
+  url: string;
 }
 
 interface TsNode extends BaseNode {
@@ -165,7 +161,7 @@ function initializeNodes({
   };
 }
 
-export type { NodeConfiguration, TsNode, NearestNode, UrlString };
+export type { NodeConfiguration, TsNode, NearestNode };
 
 export {
   nodeDueForHealthcheck,

--- a/tests/node.test.ts
+++ b/tests/node.test.ts
@@ -1,4 +1,4 @@
-import type { NearestNode, NodeConfiguration, TsNode, UrlString } from "@/node";
+import type { NearestNode, NodeConfiguration, TsNode } from "@/node";
 
 import {
   getNextNode,
@@ -12,27 +12,27 @@ import { describe, expect, it } from "vitest";
 describe("type tests", () => {
   describe("NodeConfiguration", () => {
     it("should not let a url be defined when host, port, or protocol are defined", () => {
+      // @ts-expect-error This is erroring as expected
       const _host: NodeConfiguration = {
         host: "localhost",
-        // @ts-expect-error This is erroring as expected
         url: "http://localhost:3000",
       };
 
+      // @ts-expect-error This is erroring as expected
       const _port: NodeConfiguration = {
         port: 3000,
-        // @ts-expect-error This is erroring as expected
         url: "http://localhost:3000",
       };
 
+      // @ts-expect-error This is erroring as expected
       const _protocol: NodeConfiguration = {
         protocol: "http",
-        // @ts-expect-error This is erroring as expected
         url: "http://localhost:3000",
       };
 
+      // @ts-expect-error This is erroring as expected
       const _path: NodeConfiguration = {
         path: "/api",
-        // @ts-expect-error This is erroring as expected
         url: "http://localhost:3000",
       };
     });
@@ -70,14 +70,6 @@ describe("type tests", () => {
           protocol: "ftp",
         };
       });
-    });
-  });
-  describe("UrlString", () => {
-    it("should only let a protocol be http or https", () => {
-      const _http: UrlString = "http://localhost:3000";
-      const _https: UrlString = "https://localhost:3000";
-      // @ts-expect-error This is erroring as expected
-      const _error: UrlString = "ftp://localhost:3000";
     });
   });
 });


### PR DESCRIPTION
fix #8 by making the url string just a common string, to be able to read from environment variables easily.