### PR TITLE
perf(fetch/import): stream JSONL body so large imports don't OOM in serverless

### DIFF
--- a/src/http/fetch/collection.ts
+++ b/src/http/fetch/collection.ts
@@ -47,6 +47,30 @@ class DocumentImportError extends Error {
   }
 }
 
+// JSONL request body that stringifies one document at a time -- avoids the
+// O(N) intermediate string allocation of `docs.map(JSON.stringify).join("\n")`,
+// which OOMs on Workers / Edge runtimes for realistic vector-embedding-sized
+// imports. The trailing newline is omitted; Typesense ignores it either way.
+function createStreamingJsonlBody(
+  documents: readonly unknown[],
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let index = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (index >= documents.length) {
+        controller.close();
+        return;
+      }
+      const trailingNewline = index < documents.length - 1 ? "\n" : "";
+      controller.enqueue(
+        encoder.encode(JSON.stringify(documents[index]) + trailingNewline),
+      );
+      index++;
+    },
+  });
+}
+
 async function retrieveAllCollections(config?: Configuration): Promise<
   (OmitDefaultSortingField<Collection> & {
     created_at: number;
@@ -248,16 +272,17 @@ function collection<
           throw new Error("Cannot import empty array");
         }
 
-        const docsInJsonl = documents
-          .map((document) => JSON.stringify(document))
-          .join("\n");
-
         const result = await makeRequest({
           endpoint: `/collections/${encodeURIComponent(schema.name)}/documents/import`,
           config: getConfiguration(config),
           method: "POST",
           params,
-          body: docsInJsonl,
+          // Stream the JSONL body one doc at a time -- the previous
+          // `.map(JSON.stringify).join("\n")` buffers the entire payload in
+          // memory, OOM'ing in serverless runtimes (Workers / Edge) for
+          // realistic imports (e.g. 100 docs with 1536-dim embeddings).
+          // Wrapped in a factory so 5xx retries get a fresh stream.
+          body: () => createStreamingJsonlBody(documents),
           isImport: true,
         });
 
@@ -289,9 +314,9 @@ function collection<
     },
     schema: collectionSchema,
     infer: collectionSchema.fields as InferNativeType<
-      typeof collectionSchema.fields extends CollectionField<string, string>[]
-        ? typeof collectionSchema.fields
-        : never
+      typeof collectionSchema.fields extends CollectionField<string, string>[] ?
+        typeof collectionSchema.fields
+      : never
     >,
 
     async create(options?: CollectionCreateOptions, config?: Configuration) {

--- a/src/http/fetch/collection.ts
+++ b/src/http/fetch/collection.ts
@@ -277,11 +277,6 @@ function collection<
           config: getConfiguration(config),
           method: "POST",
           params,
-          // Stream the JSONL body one doc at a time -- the previous
-          // `.map(JSON.stringify).join("\n")` buffers the entire payload in
-          // memory, OOM'ing in serverless runtimes (Workers / Edge) for
-          // realistic imports (e.g. 100 docs with 1536-dim embeddings).
-          // Wrapped in a factory so 5xx retries get a fresh stream.
           body: () => createStreamingJsonlBody(documents),
           isImport: true,
         });

--- a/src/http/fetch/request.ts
+++ b/src/http/fetch/request.ts
@@ -18,7 +18,10 @@ async function makeRequest<TBody, TReturn>({
 }: {
   config: Configuration;
   method: HttpMethod;
-  body?: TBody;
+  // `() => BodyInit` is a factory invoked per-attempt -- lets callers pass
+  // a `ReadableStream` (consumed on first try) while still preserving retry
+  // semantics on 5xx; see the streaming-JSONL body in `documents.import`.
+  body?: TBody | (() => BodyInit);
   params?: URLSearchParams;
   isImport?: boolean;
   endpoint?: `/${string}`;
@@ -35,15 +38,28 @@ async function makeRequest<TBody, TReturn>({
   const url = constructUrl({ baseUrl: node.node.url, params, endpoint });
 
   try {
-    const response = await fetch(url, {
+    const fetchBody =
+      isImport ?
+        typeof body === "function" ?
+          (body as () => BodyInit)()
+        : (body as BodyInit)
+      : JSON.stringify(body);
+    // Node 22+ (undici) requires `duplex: "half"` when sending a stream
+    // body. Cast because the type isn't in lib.dom yet; Workers/Deno/Bun
+    // either require or tolerate the same option.
+    const fetchInit: RequestInit & { duplex?: "half" } = {
       method,
       headers: {
         "Content-Type": isImport ? "text/plain" : "application/json",
         "X-TYPESENSE-API-KEY": config.apiKey,
         ...config.additionalHeaders,
       },
-      body: isImport ? (body as string) : JSON.stringify(body),
-    });
+      body: fetchBody,
+    };
+    if (fetchBody instanceof ReadableStream) {
+      fetchInit.duplex = "half";
+    }
+    const response = await fetch(url, fetchInit);
     const responseText = await response.text();
 
     if (response.ok) {
@@ -69,8 +85,12 @@ async function makeRequest<TBody, TReturn>({
     return makeRequest({
       method,
       config,
-      body: isImport ? body : JSON.stringify(body),
+      // Pass body unchanged -- if it's a factory, the recursive call will
+      // invoke it again to get a fresh stream for the retry.
+      body,
       params,
+      isImport,
+      endpoint,
       currentNodeIndex: node.nextIndex,
       attempt: attemptNum + 1,
     });

--- a/tests/fetch/request.test.ts
+++ b/tests/fetch/request.test.ts
@@ -176,6 +176,47 @@ describe("makeRequest", () => {
     ).rejects.toThrow("Network error");
   });
 
+  it("should stream a ReadableStream body when isImport and re-invoke factory on retry", async () => {
+    const nodes = [createNode(0, true), createNode(1, true)];
+
+    fetchMocker
+      .mockResponseOnce("Server Error", { status: 500 })
+      .mockResponseOnce('{"success":true}\n{"success":true}');
+
+    let factoryCalls = 0;
+    const bodyFactory = () => {
+      factoryCalls++;
+      return new ReadableStream<Uint8Array>({
+        pull(controller) {
+          controller.enqueue(new TextEncoder().encode('{"a":1}\n{"b":2}'));
+          controller.close();
+        },
+      });
+    };
+
+    const result = await makeRequest<unknown, unknown[]>({
+      method: "POST",
+      config: {
+        nodes,
+        apiKey: "test-key",
+        healthcheckIntervalSeconds: 1,
+        retryIntervalSeconds: 0,
+        numRetries: 3,
+      },
+      body: bodyFactory,
+      isImport: true,
+    });
+
+    expect(factoryCalls).toBe(2);
+    expect(fetchMocker.requests()).toHaveLength(2);
+    expect(result).toStrictEqual([{ success: true }, { success: true }]);
+
+    // Both attempts sent a ReadableStream body, not a string.
+    for (const call of fetchMocker.mock.calls) {
+      expect(call[1]?.body).toBeInstanceOf(ReadableStream);
+    }
+  });
+
   it("should use nearest node when healthy", async () => {
     const nodes = [createNode(0, false)];
     const nearestNode = createNearestNode(true);


### PR DESCRIPTION
## Problem

`documents.import()` builds the entire JSONL payload in memory:

```ts
const docsInJsonl = documents
  .map((document) => JSON.stringify(document))
  .join("\n");
```

For realistic imports, 100 large docs with 1536-dim embeddings is multiple megabytes JSONL, this OOMs serverless runtimes with strict memory caps (Cloudflare Workers' default is 128 MB and the limit is often hit before the import call even completes, especially when combined with the worker's own buffered docs).

## Fix

Swap the buffered string body for a `ReadableStream<Uint8Array>` that JSON-stringifies one doc at a time:

```ts
function createStreamingJsonlBody(documents: readonly unknown[]) {
  const encoder = new TextEncoder();
  let index = 0;
  return new ReadableStream<Uint8Array>({
    pull(controller) {
      if (index >= documents.length) return void controller.close();
      const trailingNewline = index < documents.length - 1 ? "\n" : "";
      controller.enqueue(encoder.encode(JSON.stringify(documents[index]) + trailingNewline));
      index++;
    },
  });
}
```

From the caller's perspective the API is identical — same inputs, same outputs, same response parsing. The streaming is purely an internal change.

## Retry support

To keep the existing 5xx retry semantics, `makeRequest`'s `body` parameter now also accepts a `() => BodyInit` factory. The recursive retry call invokes the factory again to get a fresh stream — without this, a 5xx retry would try to re-send an already-consumed `ReadableStream`. Non-import callers are unchanged (they keep passing a plain `TBody`).

The retry path also now forwards `isImport` and `endpoint` to the recursive call. Previously the defaults were used, which silently broke import-response parsing on the 5xx retry path (i.e. the retried response was `JSON.parse`d as a single object instead of split-and-parsed as JSONL). I tripped over this while wiring the factory; the fix is in the same commit.

## Node 22+ / undici note

When sending a `ReadableStream` body, undici (Node ≥ 22) requires `duplex: "half"` in `RequestInit`. Set conditionally when the resolved body is a `ReadableStream`. Workers/Deno/Bun either require or tolerate the same option. The cast is annotated.

## Tests

Added a unit test in \`tests/fetch/request.test.ts\` that:
  - Asserts the body sent to fetch is a \`ReadableStream\` (not a string) when \`isImport\` is set with a factory.
  - Asserts the factory is invoked once per attempt — verifies the 5xx retry gets a fresh stream.
  - Asserts the JSONL response is correctly split-and-parsed on the retried attempt (covers the `isImport` pass-through fix).

Full test run (against fresh Typesense via docker-compose): the 7 import-using tests in `tests/collection.test.ts` all pass cleanly under the streaming body. The pre-existing flake set (analytics-events rate limit, the multisearch/alias/override beforeAll state-sharing failures on fresh DB) reproduces identically against stock `1.0.0` — none of those are caused by this PR.

## Backwards compatibility

`documents.import()`'s public signature is unchanged. Callers continue to pass an array of docs and receive the same response shape. Existing tests in `tests/collection.test.ts` (import, return_doc, return_id, throw_on_failure, nested fields, large batches, etc.) all pass against the new implementation without modification.