### PR TITLE
fix(filter): accept runtime numeric values in filter_by

### DIFF
--- a/src/lexer/filter.ts
+++ b/src/lexer/filter.ts
@@ -265,6 +265,9 @@ type FilterTokenizer<
         >
     : Head extends NumericValue ?
       FilterTokenizer<ReadNum<T>[1], Schema, [...Acc, NumToken<ReadNum<T>[0]>]>
+    : Head extends `${number}` | `${bigint}` ?
+      // Handle an interpolated number, e.g. a runtime value in `field:=${n}`
+      FilterTokenizer<Tail, Schema, [...Acc, NumToken<Head>]>
     : `Unknown token: ${Head}`
   : T extends keyof TokenMap ?
     // Handle case when the last token is a symbol (e.g. "&&")

--- a/tests/filter.test.ts
+++ b/tests/filter.test.ts
@@ -274,6 +274,96 @@ describe("FilterTokenizer tests", () => {
       FilterTokenizer<"age != 20", typeof _usersSchema>
     >().toEqualTypeOf<"Unknown token: !">();
   });
+
+  it("should tokenize a `${number}` interpolation as a num token", () => {
+    expectTypeOf<
+      FilterTokenizer<`age:=${number}`, typeof _usersSchema>
+    >().toEqualTypeOf<[Ident<"age", "int32">, ":=", NumToken<`${number}`>]>();
+  });
+
+  it("should tokenize a `${number}` interpolation followed by a clause", () => {
+    expectTypeOf<
+      FilterTokenizer<`age:=${number} && name:John`, typeof _usersSchema>
+    >().toEqualTypeOf<
+      [
+        Ident<"age", "int32">,
+        ":=",
+        NumToken<`${number}`>,
+        "&&",
+        Ident<"name", "string">,
+        ":",
+        LiteralToken<"John">,
+      ]
+    >();
+  });
+
+  it("should tokenize `${number}` interpolations inside a range", () => {
+    expectTypeOf<
+      FilterTokenizer<`age:[${number}..${number}]`, typeof _usersSchema>
+    >().toEqualTypeOf<
+      [
+        Ident<"age", "int32">,
+        ":[",
+        NumToken<`${number}`>,
+        "..",
+        NumToken<`${number}`>,
+        "]",
+      ]
+    >();
+  });
+
+  it("should tokenize a `${bigint}` interpolation as a num token", () => {
+    expectTypeOf<
+      FilterTokenizer<`age:=${bigint}`, typeof _usersSchema>
+    >().toEqualTypeOf<[Ident<"age", "int32">, ":=", NumToken<`${bigint}`>]>();
+  });
+
+  it("should still tokenize literal numbers with their exact value", () => {
+    expectTypeOf<
+      FilterTokenizer<"age:=20", typeof _usersSchema>
+    >().toEqualTypeOf<[Ident<"age", "int32">, ":=", NumToken<"20">]>();
+  });
+});
+
+describe("ParseFilter with runtime `${number}` values", () => {
+  it("should accept a runtime numeric value with `:=`", () => {
+    expectTypeOf<
+      ParseFilter<`age:=${number}`, typeof _usersSchema>
+    >().toEqualTypeOf<true>();
+  });
+
+  it("should accept a runtime numeric value with comparison operators", () => {
+    expectTypeOf<
+      ParseFilter<`age:>${number}`, typeof _usersSchema>
+    >().toEqualTypeOf<true>();
+    expectTypeOf<
+      ParseFilter<`age:<${number}`, typeof _usersSchema>
+    >().toEqualTypeOf<true>();
+  });
+
+  it("should accept a runtime numeric value inside an array", () => {
+    expectTypeOf<
+      ParseFilter<`age:[${number}]`, typeof _usersSchema>
+    >().toEqualTypeOf<true>();
+  });
+
+  it("should accept a runtime numeric range", () => {
+    expectTypeOf<
+      ParseFilter<`age:[${number}..${number}]`, typeof _usersSchema>
+    >().toEqualTypeOf<true>();
+  });
+
+  it("should accept a runtime numeric value followed by another clause", () => {
+    expectTypeOf<
+      ParseFilter<`age:=${number} && name:John`, typeof _usersSchema>
+    >().toEqualTypeOf<true>();
+  });
+
+  it("should accept a runtime bigint value", () => {
+    expectTypeOf<
+      ParseFilter<`age:=${bigint}`, typeof _usersSchema>
+    >().toEqualTypeOf<true>();
+  });
 });
 
 describe("IsNextTokenValid type tests", () => {


### PR DESCRIPTION
### Problem

Interpolating a runtime `number` into a filter fails to type-check:

```ts
const n: number = 1214009;
multisearchEntry({
  collection: "matters",
  q: "*",
  query_by: ["title"],
  filter_by: `humanReadableId:=${n}`, // Error: Unknown token: ${number}
});
```

The value `humanReadableId:=1214009` is valid at runtime, but there's currently no way to pass a runtime numeric value into `filter_by`. The backtick escape that works for string fields (`` field:=`${value}` ``) doesn't help here — Typesense rejects a backtick-quoted number with "Numerical field has an invalid comparator". So the one form that type-checks is the one the engine refuses, and vice-versa.

### Cause

When a `number` is interpolated, the value arrives as the template-literal type `` `${number}` ``. The tokenizer's char-split (`T extends \`${infer Head}${infer Tail}\``) collapses the whole placeholder into `Head`, which doesn't extend `NumericValue` (`Digit | "." | "-"`), so it falls through to `Unknown token: ${number}`. It's a coverage gap in the tokenizer.

### Fix

Add a `FilterTokenizer` branch that treats a `` `${number}` ``/`` `${bigint}` `` placeholder as a `NumToken` and recurses on the tail. It's placed after the literal `NumericValue` branch, so literal digits still go through `ReadNum` and keep their exact value (`NumToken<"20">`). The tail recursion handles continuation clauses, arrays, and ranges:

- `humanReadableId:=${n}` -> valid
- `humanReadableId:=${n} && title:foo` -> valid
- `humanReadableId:[${n}]` and `humanReadableId:[${a}..${b}]` -> valid

Invalid filters are still rejected (wrong operator for a numeric field, unknown fields, etc.) — the fix isn't over-permissive.

### Tests

Added tokenizer and `ParseFilter` cases for `${number}`/`${bigint}` interpolation across `:=`, comparisons, arrays, ranges, and continuation clauses, plus a guard that literal numbers keep their exact `NumToken` value.
