### PR TITLE
fix(search): comma-join highlight_full_fields before sending

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -388,15 +388,25 @@ type ArraySearchParams<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   > extends any[] | TupleOfLength<any> ?
     K
-  : NonNullable<
-    SearchParams<Schema, FilterBy, SortBy, Q, CollectionName, QueryByTuple>[K]
-  > extends infer T ?
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    T extends TupleOfLength<any, any> ? K
-    : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    T extends TupleOfLength<any, any> ? K
-    : never
-  : never;
+  : // Also catch unions with an array member (e.g. `"none" | string[]`)
+  [
+    Extract<
+      NonNullable<
+        SearchParams<
+          Schema,
+          FilterBy,
+          SortBy,
+          Q,
+          CollectionName,
+          QueryByTuple
+        >[K]
+      >,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      readonly any[]
+    >,
+  ] extends [never] ?
+    never
+  : K;
 }[keyof SearchParams<
   Schema,
   FilterBy,
@@ -421,6 +431,7 @@ const ARRAY_KEYS = {
   num_typos: true,
   facet_return_parent: true,
   stopwords: true,
+  highlight_full_fields: true,
 } as const satisfies Record<NonNullable<ArraySearchParams>, true>;
 
 interface BaseHighlightV1<T extends CollectionField> {

--- a/tests/serialization.test.ts
+++ b/tests/serialization.test.ts
@@ -1,0 +1,132 @@
+import { configure, setDefaultConfiguration } from "@/config";
+import { collection } from "@/http/fetch";
+import { multisearch } from "@/http/fetch/multisearch";
+import { multisearchEntry } from "@/multisearch";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { testNode } from "./support";
+
+// Stub fetch so we can assert how array params are serialized onto the wire
+// without needing a live Typesense instance.
+
+const _serialization_schema = collection({
+  fields: [
+    { name: "content", type: "string" },
+    { name: "title", type: "string" },
+  ],
+  name: "serialization_test",
+});
+
+declare module "@/collection/base" {
+  interface Collections {
+    serialization_test: typeof _serialization_schema.schema;
+  }
+}
+
+const config = configure({
+  apiKey: "xyz",
+  nodes: [testNode],
+});
+
+function stubFetch(body: unknown) {
+  const fetchMock = vi.fn((_url: string, _init: RequestInit) =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function lastRequestUrl(fetchMock: ReturnType<typeof stubFetch>): string {
+  const call = fetchMock.mock.calls.at(-1);
+  if (!call) throw new Error("fetch was not called");
+  return call[0];
+}
+
+function lastRequestBody(fetchMock: ReturnType<typeof stubFetch>): unknown {
+  const call = fetchMock.mock.calls.at(-1);
+  if (!call) throw new Error("fetch was not called");
+  return JSON.parse(call[1].body as string);
+}
+
+function firstSearch(body: unknown): Record<string, unknown> {
+  const searches = (body as { searches: Record<string, unknown>[] }).searches;
+  const search = searches[0];
+  if (!search) throw new Error("no searches in body");
+  return search;
+}
+
+beforeAll(() => {
+  setDefaultConfiguration({ apiKey: "xyz", nodes: [testNode] });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("array param serialization", () => {
+  it("comma-joins highlight_full_fields in a per-collection search", async () => {
+    const fetchMock = stubFetch({ hits: [] });
+
+    await _serialization_schema.search(
+      {
+        q: "hello",
+        query_by: ["content"],
+        highlight_full_fields: ["content"],
+      },
+      config,
+    );
+
+    // The per-collection search path serializes params into the query string.
+    const params = new URL(lastRequestUrl(fetchMock)).searchParams;
+    expect(params.get("highlight_full_fields")).toBe("content");
+    expect(params.get("query_by")).toBe("content");
+  });
+
+  it("comma-joins highlight_full_fields in a multi-search body", async () => {
+    const fetchMock = stubFetch({ results: [{ hits: [] }] });
+
+    await multisearch(
+      {
+        searches: [
+          multisearchEntry({
+            collection: "serialization_test",
+            q: "hello",
+            query_by: ["content"],
+            highlight_full_fields: ["content"],
+          }),
+        ],
+      },
+      config,
+    );
+
+    const search = firstSearch(lastRequestBody(fetchMock));
+    expect(search.highlight_full_fields).toBe("content");
+    expect(search.query_by).toBe("content");
+  });
+
+  it("comma-joins multiple highlight_full_fields values", async () => {
+    const fetchMock = stubFetch({ results: [{ hits: [] }] });
+
+    await multisearch(
+      {
+        searches: [
+          multisearchEntry({
+            collection: "serialization_test",
+            q: "hello",
+            query_by: ["content", "title"],
+            highlight_full_fields: ["content", "title"],
+          }),
+        ],
+      },
+      config,
+    );
+
+    const search = firstSearch(lastRequestBody(fetchMock));
+    expect(search.highlight_full_fields).toBe("content,title");
+  });
+});


### PR DESCRIPTION
### Problem

Any search passing `highlight_full_fields` fails with HTTP 400 `One or more search parameters are malformed`, even though the call type-checks:

```ts
multisearchEntry({
  collection: "ai_messages",
  q: "hello",
  query_by: ["content"],
  highlight_full_fields: ["content"], // 400s the whole multi-search
});
```

At the wire level, `query_by`/`group_by` are correctly comma-joined but `highlight_full_fields` goes out as a raw JSON array `["content"]`, which Typesense rejects. The comma-joined string `"content"` returns 200.

### Cause

Array-typed params are comma-joined before sending, against the `ARRAY_KEYS` allowlist. `highlight_full_fields` was missing from it.

The allowlist is meant to stay in sync via `satisfies Record<NonNullable<ArraySearchParams>, true>`, but `ArraySearchParams` only matched params whose whole type extends `any[]`. `highlight_full_fields` is typed `"none" | SubsetTuple<...>` — a union that doesn't extend `any[]` as a whole — so it was silently excluded and the guard never flagged it. Simply adding the key to `ARRAY_KEYS` is rejected as an excess property until the extractor is fixed.

### Fix

Two parts:

1. Fix the `ArraySearchParams` extractor to also match params with an array *member* (via `Extract<..., readonly any[]>`), so union types like `"none" | string[]` are detected. (Also drops a duplicated dead branch it had.)
2. Add `highlight_full_fields` to `ARRAY_KEYS`.

I confirmed the corrected extractor yields exactly the previous keys plus `highlight_full_fields` — no other fields changed — so the `satisfies` guard now covers this class of param and will fail the build if a future array param is added without being allowlisted.

Note: only the multi-search (JSON body) path actually 400s. The per-collection search path builds a query string via `URLSearchParams`, which coerces arrays to comma-strings anyway, so it was unaffected — but it's now consistent.

### Tests

Added serialization tests (stubbed `fetch`, no live server) asserting tuple -> comma-string for `highlight_full_fields` in both the search and multi-search paths.