### PR TITLE
fix(fetch): forward endpoint, isImport, and body unchanged on retry

### DIFF
--- a/src/http/fetch/request.ts
+++ b/src/http/fetch/request.ts
@@ -69,8 +69,10 @@ async function makeRequest<TBody, TReturn>({
     return makeRequest({
       method,
       config,
-      body: isImport ? body : JSON.stringify(body),
+      body,
       params,
+      endpoint,
+      isImport,
       currentNodeIndex: node.nextIndex,
       attempt: attemptNum + 1,
     });

--- a/tests/fetch/request.test.ts
+++ b/tests/fetch/request.test.ts
@@ -87,6 +87,68 @@ describe("makeRequest", () => {
     expect(urls[1].searchParams.get("q")).toBe("query");
   });
 
+  it("should keep the endpoint and body when retrying after a 5xx", async () => {
+    const nodes = [createNode(0, true), createNode(1, true)];
+
+    fetchMocker
+      .mockResponseOnce("Server Error", { status: 500 })
+      .mockResponseOnce(JSON.stringify({ data: "success" }));
+
+    await makeRequest({
+      method: "POST",
+      endpoint: "/collections",
+      config: {
+        nodes,
+        apiKey: "test-key",
+        healthcheckIntervalSeconds: 1,
+        retryIntervalSeconds: 0,
+        numRetries: 3,
+      },
+      body: { test: "data" },
+    });
+
+    expect(fetchMocker.requests()).toHaveLength(2);
+    expect(new URL(fetchMocker.requests()[1]!.url).pathname).toBe(
+      "/collections",
+    );
+    expect(fetchMocker.mock.calls[1]?.[1]?.body).toBe(
+      JSON.stringify({ test: "data" }),
+    );
+  });
+
+  it("should keep the import body and content type when retrying after a 5xx", async () => {
+    const nodes = [createNode(0, true), createNode(1, true)];
+    const importBody = `${JSON.stringify({ id: "1" })}\n${JSON.stringify({ id: "2" })}`;
+
+    fetchMocker
+      .mockResponseOnce("Server Error", { status: 500 })
+      .mockResponseOnce(JSON.stringify({ success: true }));
+
+    await makeRequest({
+      method: "POST",
+      endpoint: "/collections/test/documents/import",
+      isImport: true,
+      config: {
+        nodes,
+        apiKey: "test-key",
+        healthcheckIntervalSeconds: 1,
+        retryIntervalSeconds: 0,
+        numRetries: 3,
+      },
+      body: importBody,
+    });
+
+    expect(fetchMocker.requests()).toHaveLength(2);
+    expect(new URL(fetchMocker.requests()[1]!.url).pathname).toBe(
+      "/collections/test/documents/import",
+    );
+    const retryInit = fetchMocker.mock.calls[1]?.[1];
+    expect(retryInit?.body).toBe(importBody);
+    expect((retryInit?.headers as Record<string, string>)["Content-Type"]).toBe(
+      "text/plain",
+    );
+  });
+
   it("should throw RequestError immediately on 4xx error", async () => {
     const nodes = [createNode(0, true)];
 


### PR DESCRIPTION
Fixes #17.

The retry after a 5xx in `makeRequest` rebuilt the named arguments and got three of them wrong:

- `endpoint` was not passed, so the retried request went to the bare node URL with no path and got a 404.
- `isImport` was not passed and reset to false, so a retried import lost its `text/plain` content type and its JSONL body was JSON.stringified.
- `body` was pre-stringified for non-import requests, then stringified again at the `fetch` call, so the server received a double-encoded string.

This forwards all arguments unchanged. The `fetch` call already handles the import/non-import body distinction.

Added two regression tests to `tests/fetch/request.test.ts` in the style of the existing ones. Both fail against the current `1.0.0` branch and pass with the fix:

- retry after a 5xx keeps the endpoint path and sends an identical body
- retry of an import keeps the JSONL body and `text/plain` content type

Ran `vitest run tests/fetch/request.test.ts` (8 passed), `tsc --noEmit`, `eslint`, and `prettier --check` on the changed files.
